### PR TITLE
Adding Block Number API + React Hook

### DIFF
--- a/apps/build-onchain-apps/package.json
+++ b/apps/build-onchain-apps/package.json
@@ -9,6 +9,7 @@
     "format:check": "prettier --check .",
     "lint": "next lint --fix",
     "lint:check": "next lint",
+    "check": "yarn format && yarn lint && yarn test && yarn test:coverage",
     "start": "next start",
     "stylelint": "stylelint '**/*.css'",
     "test": "jest .",

--- a/apps/build-onchain-apps/pages/api/README.md
+++ b/apps/build-onchain-apps/pages/api/README.md
@@ -9,3 +9,17 @@
 ```json
 [{"id":5,"network":"goerli","name":"Goerli"]
 ```
+
+## Current Block Number /api/chain/blockNumber?chainId=5
+
+Gets the current blocknumber from the backend. This might be used to ensure
+your frontend has consistency with the backend (e.g what if the drift
+between FE and BE).
+
+**Method**: GET
+
+**Response**: JSON encoded block number
+
+```json
+{"block":"13948678"}
+```

--- a/apps/build-onchain-apps/pages/api/README.md
+++ b/apps/build-onchain-apps/pages/api/README.md
@@ -21,5 +21,5 @@ between FE and BE).
 **Response**: JSON encoded block number
 
 ```json
-{"block":"13948678"}
+{ "block": "13948678" }
 ```

--- a/apps/build-onchain-apps/pages/api/chain/currentBlockNumber.test.ts
+++ b/apps/build-onchain-apps/pages/api/chain/currentBlockNumber.test.ts
@@ -1,0 +1,60 @@
+import { baseGoerli } from 'viem/chains';
+import { getChainsForEnvironment } from '../../../src/utils/chainConfiguration';
+import { getRpcProviderForChain } from '../../../src/utils/provider';
+import handler from './currentBlockNumber';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+jest.mock('../../../src/utils/chainConfiguration');
+jest.mock('../../../src/utils/provider');
+
+describe('/api/chain/blockNumber', () => {
+  let req: Partial<NextApiRequest>;
+  let res: Partial<NextApiResponse>;
+  let mockProvider: { getBlockNumber: jest.Mock };
+  const unknownChainId = '73264023';
+  const getChainsMock = getChainsForEnvironment as jest.Mock;
+
+  beforeEach(() => {
+    req = { query: {} };
+    res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    mockProvider = { getBlockNumber: jest.fn() };
+    (getRpcProviderForChain as jest.Mock).mockReturnValue(mockProvider);
+  });
+
+  it('returns 400 if chainId is missing', async () => {
+    await handler(req as NextApiRequest, res as NextApiResponse);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'chainid is required' });
+  });
+
+  it('returns 400 if chainId is not supported', async () => {
+    getChainsMock.mockReturnValue([]);
+    if (!req.query) {
+      req.query = {};
+    }
+    req.query = { chainId: unknownChainId };
+    await handler(req as NextApiRequest, res as NextApiResponse);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'chainid not supported' });
+  });
+
+  it('returns 200 with block number on valid chainId', async () => {
+    const mockBlockNumber = 123456;
+    getChainsMock.mockReturnValue([{ id: baseGoerli.id }]);
+    mockProvider.getBlockNumber.mockResolvedValue(mockBlockNumber);
+    req.query = { chainId: baseGoerli.id.toString() };
+    await handler(req as NextApiRequest, res as NextApiResponse);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ block: mockBlockNumber.toString() });
+  });
+
+  it('returns 500 on internal server error', async () => {
+    getChainsMock.mockImplementation(() => {
+      throw new Error('Test error');
+    });
+    req.query = { chainId: unknownChainId };
+    await handler(req as NextApiRequest, res as NextApiResponse);
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Internal server error' });
+  });
+});

--- a/apps/build-onchain-apps/pages/api/chain/currentBlockNumber.ts
+++ b/apps/build-onchain-apps/pages/api/chain/currentBlockNumber.ts
@@ -1,0 +1,33 @@
+import { Chain } from 'viem/chains';
+import { getChainsForEnvironment } from '../../../src/utils/chainConfiguration';
+import { getRpcProviderForChain } from '../../../src/utils/provider';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+/**
+ * Handler for the /api/chain/blockNumber route, this route will return the current block number
+ * @param req
+ * @param res
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    // Get the Chain Id from the request
+    const chainId = req.query.chainId;
+    if (!chainId) {
+      return res.status(400).json({ error: 'chainid is required' });
+    }
+
+    // Check if the chain is supported
+    const chains = getChainsForEnvironment();
+    const filteredChains = chains?.filter((c: Chain) => c.id === Number(chainId));
+    if (!filteredChains?.length) {
+      return res.status(400).json({ error: 'chainid not supported' });
+    }
+    const chain = filteredChains[0];
+    const provider = getRpcProviderForChain(chain);
+    const block = await provider.getBlockNumber();
+    return res.status(200).json({ block: block.toString() });
+  } catch (error) {
+    console.error('Error fetching chains:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+}

--- a/apps/build-onchain-apps/src/hooks/useBlockNumber.test.ts
+++ b/apps/build-onchain-apps/src/hooks/useBlockNumber.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { useNetwork } from 'wagmi';
+import { renderHook, waitFor } from '@testing-library/react';
+import useCurrentBlockNumber from './useBlockNumber';
+
+jest.mock('wagmi', () => ({
+  useNetwork: jest.fn(),
+}));
+
+global.fetch = jest.fn(async () =>
+  Promise.resolve({
+    ok: true,
+    json: async () => Promise.resolve({ block: 123 }),
+  }),
+) as jest.Mock;
+
+describe('useCurrentBlockNumber', () => {
+  it('should initially set block number to 0 and loading to false', () => {
+    (useNetwork as jest.Mock).mockReturnValue({ chain: { id: null } });
+    const { result } = renderHook(() => useCurrentBlockNumber());
+    expect(result.current.blockNumber).toBe(0);
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('should update block number and loading state when chainId is present', async () => {
+    (useNetwork as jest.Mock).mockReturnValue({ chain: { id: 1 } });
+    const { result } = renderHook(() => useCurrentBlockNumber());
+    await waitFor(() =>
+      expect(result.current).toMatchObject({ blockNumber: 123, isLoading: false }),
+    );
+  });
+});

--- a/apps/build-onchain-apps/src/hooks/useBlockNumber.ts
+++ b/apps/build-onchain-apps/src/hooks/useBlockNumber.ts
@@ -27,7 +27,7 @@ const useCurrentBlockNumber = (refreshIntervalMs = 10000) => {
           throw new Error(`Error: ${response.status}`);
         }
 
-        const data: BlockNumberResponse = (await response.json()) as BlockNumberResponse;
+        const data = (await response.json()) as BlockNumberResponse;
         setBlockNumber(data.block);
       } catch (err) {
         // Handle error

--- a/apps/build-onchain-apps/src/hooks/useBlockNumber.ts
+++ b/apps/build-onchain-apps/src/hooks/useBlockNumber.ts
@@ -1,0 +1,55 @@
+import { useState, useEffect } from 'react';
+import { useNetwork } from 'wagmi';
+
+type BlockNumberResponse = {
+  block: number;
+};
+const useCurrentBlockNumber = (refreshIntervalMs = 10000) => {
+  const [blockNumber, setBlockNumber] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+  const { chain } = useNetwork();
+  const chainId = chain?.id;
+
+  useEffect(() => {
+    let intervalId: NodeJS.Timeout;
+
+    const fetchBlockNumber = async () => {
+      if (!chainId) {
+        setBlockNumber(0);
+        return;
+      }
+
+      setIsLoading(true);
+
+      try {
+        const response = await fetch(`/api/chain/currentBlockNumber?chainId=${chainId}`);
+        if (!response.ok) {
+          throw new Error(`Error: ${response.status}`);
+        }
+
+        const data: BlockNumberResponse = (await response.json()) as BlockNumberResponse;
+        setBlockNumber(data.block);
+      } catch (err) {
+        // Handle error
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    // Refresh current block number every 15 seconds.
+    const fetchBlockNumberWrapper = () => {
+      fetchBlockNumber().catch(console.error); // Handle promise rejection
+    };
+    // TODO: Implement a shared state or other mechanism to prevent overloading the backend with multiple intervals.
+    intervalId = setInterval(fetchBlockNumberWrapper, refreshIntervalMs);
+    void fetchBlockNumber();
+
+    return () => {
+      clearInterval(intervalId); // Clear interval on cleanup
+    };
+  }, [chainId, refreshIntervalMs]);
+
+  return { isLoading, blockNumber };
+};
+
+export default useCurrentBlockNumber;

--- a/apps/build-onchain-apps/src/onchain/AccountConnectButton.tsx
+++ b/apps/build-onchain-apps/src/onchain/AccountConnectButton.tsx
@@ -2,7 +2,6 @@ import { useAccount, useBalance, useDisconnect, useNetwork } from 'wagmi';
 import { Box, Button, Flex, Dialog, Text } from '@radix-ui/themes';
 import { useCallback } from 'react';
 import { ConnectButton } from '@rainbow-me/rainbowkit';
-import useCurrentBlockNumber from '../hooks/useBlockNumber';
 import { getSlicedAddress } from './utils/address';
 import { getAccountBalance } from './utils/balance';
 import '@rainbow-me/rainbowkit/styles.css';
@@ -16,7 +15,6 @@ export function AccountConnectButton() {
     address,
   });
   const { disconnect } = useDisconnect();
-  const block = useCurrentBlockNumber();
   const network = useNetwork();
   const handleDisconnectWallet = useCallback(() => {
     disconnect();
@@ -98,15 +96,6 @@ export function AccountConnectButton() {
                         </Text>
                         <Text as="div" size="2" mb="1" weight="regular">
                           {network.chain?.name} ({network.chain?.id})
-                        </Text>
-                      </Flex>
-
-                      <Flex gap="3">
-                        <Text as="div" size="2" mb="1" weight="bold">
-                          Block Number:
-                        </Text>
-                        <Text as="div" size="2" mb="1" weight="regular">
-                          {block.isLoading ? 'Loading...' : block.blockNumber?.toString()}
                         </Text>
                       </Flex>
 

--- a/apps/build-onchain-apps/src/onchain/AccountConnectButton.tsx
+++ b/apps/build-onchain-apps/src/onchain/AccountConnectButton.tsx
@@ -1,7 +1,8 @@
-import { useAccount, useBalance, useDisconnect } from 'wagmi';
-import { Box, Button, Flex, Dialog } from '@radix-ui/themes';
+import { useAccount, useBalance, useDisconnect, useNetwork } from 'wagmi';
+import { Box, Button, Flex, Dialog, Text } from '@radix-ui/themes';
 import { useCallback } from 'react';
 import { ConnectButton } from '@rainbow-me/rainbowkit';
+import useCurrentBlockNumber from '../hooks/useBlockNumber';
 import { getSlicedAddress } from './utils/address';
 import { getAccountBalance } from './utils/balance';
 import '@rainbow-me/rainbowkit/styles.css';
@@ -15,7 +16,8 @@ export function AccountConnectButton() {
     address,
   });
   const { disconnect } = useDisconnect();
-
+  const block = useCurrentBlockNumber();
+  const network = useNetwork();
   const handleDisconnectWallet = useCallback(() => {
     disconnect();
   }, [disconnect]);
@@ -89,6 +91,24 @@ export function AccountConnectButton() {
                       <Dialog.Description size="2" mb="4">
                         ~~~
                       </Dialog.Description>
+
+                      <Flex gap="3">
+                        <Text as="div" size="2" mb="1" weight="bold">
+                          Network:
+                        </Text>
+                        <Text as="div" size="2" mb="1" weight="regular">
+                          {network.chain?.name} ({network.chain?.id})
+                        </Text>
+                      </Flex>
+
+                      <Flex gap="3">
+                        <Text as="div" size="2" mb="1" weight="bold">
+                          Block Number:
+                        </Text>
+                        <Text as="div" size="2" mb="1" weight="regular">
+                          {block.isLoading ? 'Loading...' : block.blockNumber?.toString()}
+                        </Text>
+                      </Flex>
 
                       <Flex gap="3" mt="4" justify="end">
                         <Dialog.Close onClick={handleCopyAddress}>

--- a/apps/build-onchain-apps/src/utils/provider.ts
+++ b/apps/build-onchain-apps/src/utils/provider.ts
@@ -1,0 +1,9 @@
+import { Chain } from 'viem/chains';
+import { createPublicClient, http } from 'viem';
+
+export function getRpcProviderForChain(chain: Chain) {
+  return createPublicClient({
+    chain: chain,
+    transport: http(chain.rpcUrls.default.http[0]),
+  });
+}


### PR DESCRIPTION
**What changed? Why?**
Added a blockNumber api + react hook for the FE to consume from the BE API.

1. Added new API route  `/api/chain/currentBlockNumber?chainId=${chainId}`
2. Added a new reactHook useCurrentBlockNumber
   1. Polls for the block number every 10 seconds by default
   2. Added to the AccountConnectButton feature.

**Notes to reviewers**
1. Why would we want blockNumber on the backend?

Sometimes it is helpful to get the block number from the backend to ensure the FE is in sync with network.  And mainly, that our FE And BE are in alignment.  Not the most critical feature, but this showcases how we would make a call to the BE from a react hook

2. Is interval the best idea in a react hook?

Probably not, we should implement a global state handler, will let some of react pros tackle this one @cnasc @snehkoul-cb 

**UX Changes**
Added network + blockNumber to the Account dialog: 
![image](https://github.com/coinbase/build-onchain-apps/assets/7040142/c4fa39ce-ea41-446f-8f0d-a2fa64665b1a)

**How has it been tested?**
1. Unit test + ran locally
