### PR TITLE
feat: used shikiji for some dope CodeBlock

### DIFF
--- a/apps/build-onchain-apps/package.json
+++ b/apps/build-onchain-apps/package.json
@@ -30,6 +30,7 @@
     "react-remove-scroll": "^2.5.7",
     "scroll-into-view-if-needed": "^3.1.0",
     "shikiji": "^0.9.17",
+    "shikiji-core": "^0.9.17",
     "viem": "1.19.15",
     "wagmi": "1.4.12",
     "workbox-webpack-plugin": "^7.0.0"

--- a/apps/build-onchain-apps/package.json
+++ b/apps/build-onchain-apps/package.json
@@ -29,6 +29,7 @@
     "react-dom": "^18",
     "react-remove-scroll": "^2.5.7",
     "scroll-into-view-if-needed": "^3.1.0",
+    "shikiji": "^0.9.17",
     "viem": "1.19.15",
     "wagmi": "1.4.12",
     "workbox-webpack-plugin": "^7.0.0"

--- a/apps/build-onchain-apps/src/components/CodeBlock/CodeBlock.module.css
+++ b/apps/build-onchain-apps/src/components/CodeBlock/CodeBlock.module.css
@@ -3,7 +3,7 @@
   width: 100%;
   border-radius: 8px;
   margin: 0;
-  background-color: #161618;
+  background-color: #000;
   overflow-x: auto;
   transition: background-color 0.5s;
 }
@@ -42,18 +42,8 @@
 .CodeBlockPre {
   position: relative;
   z-index: 1;
-  padding: 20px 0;
+  padding: 20px 24px;
   margin: 0;
   background: transparent;
   overflow-x: auto;
-}
-
-.CodeBlockCode {
-  width: fit-content;
-  min-width: 100%;
-  padding: 0 24px;
-  color: var(--vp-code-block-color);
-  font-size: 15px;
-  line-height: 1.7;
-  transition: rgb(235 235 245 / 60%);
 }

--- a/apps/build-onchain-apps/src/components/CodeBlock/CodeBlock.tsx
+++ b/apps/build-onchain-apps/src/components/CodeBlock/CodeBlock.tsx
@@ -1,4 +1,7 @@
-import { getHighlighter } from 'shikiji';
+import { getHighlighterCore } from 'shikiji/core';
+import { getWasmInlined } from 'shikiji/wasm';
+import vitesseBlack from 'shikiji/themes/vitesse-black.mjs';
+import shellscriptLang from 'shikiji/langs/shellscript.mjs';
 import { useEffect, useState } from 'react';
 import isClient from '../../utils/isClient';
 import styles from './CodeBlock.module.css';
@@ -9,14 +12,15 @@ function Code({ code }: { code: string }) {
     if (!isClient() || !code) {
       return;
     }
-    getHighlighter({
-      themes: ['nord'],
-      langs: ['javascript'],
+    getHighlighterCore({
+      themes: [vitesseBlack],
+      langs: [shellscriptLang],
+      loadWasm: getWasmInlined,
     })
       .then((highlighter) => {
         const html = highlighter.codeToHtml(code, {
-          lang: 'javascript',
-          theme: 'nord',
+          lang: 'shellscript',
+          theme: 'vitesse-black',
         });
         setHtml(html);
       })

--- a/apps/build-onchain-apps/src/components/CodeBlock/CodeBlock.tsx
+++ b/apps/build-onchain-apps/src/components/CodeBlock/CodeBlock.tsx
@@ -1,11 +1,39 @@
+import { getHighlighter } from 'shikiji';
+import { useEffect, useState } from 'react';
+import isClient from '../../utils/isClient';
 import styles from './CodeBlock.module.css';
 
-export default function CodeBlock({ children }: { children: React.ReactNode }) {
+function Code({ code }: { code: string }) {
+  const [innerHtml, setHtml] = useState('...');
+  useEffect(() => {
+    if (!isClient() || !code) {
+      return;
+    }
+    getHighlighter({
+      themes: ['nord'],
+      langs: ['javascript'],
+    })
+      .then((highlighter) => {
+        const html = highlighter.codeToHtml(code, {
+          lang: 'javascript',
+          theme: 'nord',
+        });
+        setHtml(html);
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  }, [code]);
+  // eslint-disable-next-line react/no-danger
+  return <code dangerouslySetInnerHTML={{ __html: innerHtml }} />;
+}
+
+export default function CodeBlock({ code }: { code: string }) {
   return (
     <div className={styles.CodeBlock}>
       <span className={styles.CodeBlockLang}>sh</span>
       <pre className={styles.CodeBlockPre}>
-        <code className={styles.CodeBlockCode}>{children}</code>
+        <Code code={code} />
       </pre>
     </div>
   );

--- a/apps/build-onchain-apps/src/components/home/Guide.tsx
+++ b/apps/build-onchain-apps/src/components/home/Guide.tsx
@@ -1,5 +1,8 @@
 import CodeBlock from '../CodeBlock/CodeBlock';
 
+const codeStep1 = `$ npx @coinbase/build-onchain-apps@latest create`;
+const codeStep2 = `NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=ADD_WALLET_CONNECT_PROJECT_ID_HERE`;
+
 export default function Guide() {
   return (
     <>
@@ -9,9 +12,7 @@ export default function Guide() {
         <h4 className="mb-2 text-2xl font-normal text-white">STEP 1</h4>
         <p className="text-xl font-normal text-zinc-400">Kick off your onchain app</p>
         <div className="mt-4 flex">
-          <CodeBlock>
-            <span>$</span> <span>npx @coinbase/build-onchain-apps@latest create</span>
-          </CodeBlock>
+          <CodeBlock code={codeStep1} />
         </div>
       </section>
       <section className="mt-16 flex flex-col">
@@ -24,10 +25,7 @@ export default function Guide() {
           and assign to the .env.local file
         </p>
         <div className="mt-4 flex">
-          <CodeBlock>
-            <span>NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=</span>
-            <span>ADD_WALLET_CONNECT_PROJECT_ID_HERE</span>
-          </CodeBlock>
+          <CodeBlock code={codeStep2} />
         </div>
       </section>
     </>

--- a/apps/build-onchain-apps/src/components/home/Guide.tsx
+++ b/apps/build-onchain-apps/src/components/home/Guide.tsx
@@ -2,6 +2,33 @@ import CodeBlock from '../CodeBlock/CodeBlock';
 
 const codeStep1 = `$ npx @coinbase/build-onchain-apps@latest create`;
 const codeStep2 = `NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID=ADD_WALLET_CONNECT_PROJECT_ID_HERE`;
+const codeStep3 = `# Install dependencies
+yarn
+
+# Run onchain app
+yarn dev`;
+const codeStep4 = `# Install Foundry
+
+curl -L https://foundry.paradigm.xyz | bash
+foundryup`;
+const codeStep5 = `cd contracts
+
+# Install dependencies
+forge install
+
+# Build
+forge build
+
+# Test
+forge test
+
+# Format
+forge fmt`;
+const codeStep6 = `# Create a .env file using the .env.example file provided in your contracts folder and add your private key.
+source .env
+
+forge script script/BuyMeACoffee.s.sol:BuyMeACoffeeScript --broadcast --verify --rpc-url $\{RPC_URL\} --etherscan-api-key $\{BLOCK_EXPLORER_API_KEY\}
+`;
 
 export default function Guide() {
   return (
@@ -9,24 +36,42 @@ export default function Guide() {
       <h3 className="mb-6 text-4xl font-medium text-white">Getting started</h3>
       <div className="h-px bg-white" />
       <section className="mt-10 flex flex-col">
-        <h4 className="mb-2 text-2xl font-normal text-white">STEP 1</h4>
-        <p className="text-xl font-normal text-zinc-400">Kick off your onchain app</p>
-        <div className="mt-4 flex">
-          <CodeBlock code={codeStep1} />
-        </div>
+        <h4 className="text-xl font-normal text-white">Step 1</h4>
+        <p className="my-4 text-base font-normal text-zinc-400">Kick off your onchain app</p>
+        <CodeBlock code={codeStep1} />
       </section>
-      <section className="mt-16 flex flex-col">
-        <h4 className="mb-2 text-2xl font-normal text-white">STEP 2</h4>
-        <p className="text-xl font-normal text-zinc-400">
+      <section className="mt-8 flex flex-col">
+        <h4 className="text-xl font-normal text-white">Step 2</h4>
+        <p className="my-4 text-base font-normal text-zinc-400">
           Obtain Wallet Connect Project ID from{' '}
           <a href="https://walletconnect.com/" target="_blank">
             walletconnect.com
           </a>
           and assign to the .env.local file
         </p>
-        <div className="mt-4 flex">
-          <CodeBlock code={codeStep2} />
-        </div>
+        <CodeBlock code={codeStep2} />
+      </section>
+      <section className="mt-8 flex flex-col">
+        <h4 className="text-xl font-normal text-white">Step 3</h4>
+        <p className="my-4 text-base font-normal text-zinc-400">Install and Run your onchain app</p>
+        <CodeBlock code={codeStep3} />
+      </section>
+      <section className="mt-8 flex flex-col">
+        <h4 className="text-xl font-normal text-white">Step 4</h4>
+        <p className="my-4 text-base font-normal text-zinc-400">Kick start your contracts</p>
+        <CodeBlock code={codeStep4} />
+      </section>
+      <section className="mt-8 flex flex-col">
+        <h4 className="text-xl font-normal text-white">Step 5</h4>
+        <p className="my-4 text-base font-normal text-zinc-400">
+          Build, test and format the sample contracts
+        </p>
+        <CodeBlock code={codeStep5} />
+      </section>
+      <section className="mt-8 flex flex-col">
+        <h4 className="text-xl font-normal text-white">Step 6</h4>
+        <p className="my-4 text-base font-normal text-zinc-400">Deploy contracts to Base goerli</p>
+        <CodeBlock code={codeStep6} />
       </section>
     </>
   );

--- a/apps/build-onchain-apps/src/components/home/HomeHeader.tsx
+++ b/apps/build-onchain-apps/src/components/home/HomeHeader.tsx
@@ -20,9 +20,7 @@ export default function HomeHeader() {
           Build Onchain Apps Toolkit.
         </p>
         <div className={styles.HomeHeaderCta}>
-          <CodeBlock>
-            <span>$</span> <span>npx @coinbase/build-onchain-apps@latest create</span>
-          </CodeBlock>
+          <CodeBlock code="$ npx @coinbase/build-onchain-apps@latest create" />
         </div>
       </div>
       <div className={styles.HomeHeaderWaves}>

--- a/apps/build-onchain-apps/src/global.css
+++ b/apps/build-onchain-apps/src/global.css
@@ -28,6 +28,7 @@ body {
   margin: 0;
   background-color: var(--boat-color-background);
   color: var(--boat-color-text);
+  overflow-x: hidden;
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
 }

--- a/apps/build-onchain-apps/src/global.css
+++ b/apps/build-onchain-apps/src/global.css
@@ -55,7 +55,7 @@ pre {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
     'Courier New', monospace;
   font-feature-settings: normal;
-  font-size: 1em;
+  font-size: 14px;
   font-variation-settings: normal;
 }
 

--- a/apps/build-onchain-apps/src/global.css
+++ b/apps/build-onchain-apps/src/global.css
@@ -15,6 +15,11 @@
   /* Build Onchain Apps shared variables */
   --boat-color-background: var(--palette-bg-black);
   --boat-color-text: var(--palette-bg-white);
+
+  /* Indicates that the element can be rendered using 
+   * the operating system dark color scheme. 
+   * https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme */
+  color-scheme: dark;
 }
 
 *,

--- a/apps/build-onchain-apps/src/onchain/AccountConnectButton.tsx
+++ b/apps/build-onchain-apps/src/onchain/AccountConnectButton.tsx
@@ -38,8 +38,14 @@ export function AccountConnectButton() {
             {(() => {
               if (!connected) {
                 return (
-                  <button onClick={openConnectModal} type="button">
-                    Connect Wallet
+                  <button
+                    onClick={openConnectModal}
+                    type="button"
+                    className="inline-flex h-10 w-36 items-center justify-center gap-2 rounded-3xl bg-white px-4 py-2"
+                  >
+                    <div className="text-sm font-medium leading-normal text-black">
+                      Connect wallet
+                    </div>
                   </button>
                 );
               }

--- a/apps/build-onchain-apps/tailwind.config.ts
+++ b/apps/build-onchain-apps/tailwind.config.ts
@@ -1,7 +1,11 @@
 import type { Config } from 'tailwindcss';
 
 const config: Config = {
-  content: ['./pages/**/*.{js,ts,jsx,tsx,mdx}', './src/components/**/*.{js,ts,jsx,tsx,mdx}'],
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/components/**/*.{js,ts,jsx,tsx,mdx}',
+    './src/onchain/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
   theme: {
     container: {
       center: true,

--- a/apps/build-onchain-apps/yarn.lock
+++ b/apps/build-onchain-apps/yarn.lock
@@ -1564,6 +1564,7 @@ __metadata:
     react-remove-scroll: "npm:^2.5.7"
     scroll-into-view-if-needed: "npm:^3.1.0"
     shikiji: "npm:^0.9.17"
+    shikiji-core: "npm:^0.9.17"
     stylelint: "npm:^16.0.2"
     stylelint-config-idiomatic-order: "npm:^10.0.0"
     stylelint-config-standard: "npm:^35.0.0"
@@ -11174,7 +11175,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shikiji-core@npm:0.9.17":
+"shikiji-core@npm:0.9.17, shikiji-core@npm:^0.9.17":
   version: 0.9.17
   resolution: "shikiji-core@npm:0.9.17"
   checksum: 461dcb908c1f7055756a4e9a0bcdcbac6303b424a055cfa6be01c82383fe2163169bf6e12723dc93a402da5d476a796c4a3e8dcf7ba66a90ad3dcd8718836967

--- a/apps/build-onchain-apps/yarn.lock
+++ b/apps/build-onchain-apps/yarn.lock
@@ -1563,6 +1563,7 @@ __metadata:
     react-dom: "npm:^18"
     react-remove-scroll: "npm:^2.5.7"
     scroll-into-view-if-needed: "npm:^3.1.0"
+    shikiji: "npm:^0.9.17"
     stylelint: "npm:^16.0.2"
     stylelint-config-idiomatic-order: "npm:^10.0.0"
     stylelint-config-standard: "npm:^35.0.0"
@@ -11170,6 +11171,22 @@ __metadata:
   version: 3.0.0
   resolution: "shebang-regex@npm:3.0.0"
   checksum: 1dbed0726dd0e1152a92696c76c7f06084eb32a90f0528d11acd764043aacf76994b2fb30aa1291a21bd019d6699164d048286309a278855ee7bec06cf6fb690
+  languageName: node
+  linkType: hard
+
+"shikiji-core@npm:0.9.17":
+  version: 0.9.17
+  resolution: "shikiji-core@npm:0.9.17"
+  checksum: 461dcb908c1f7055756a4e9a0bcdcbac6303b424a055cfa6be01c82383fe2163169bf6e12723dc93a402da5d476a796c4a3e8dcf7ba66a90ad3dcd8718836967
+  languageName: node
+  linkType: hard
+
+"shikiji@npm:^0.9.17":
+  version: 0.9.17
+  resolution: "shikiji@npm:0.9.17"
+  dependencies:
+    shikiji-core: "npm:0.9.17"
+  checksum: ed3ab09cefcc61f9e205f0b9dc32aef913dac975e0f267d5a2f1c2bf67bf5d62ae7353e92f7f7c974646d4136408b2acf174e60543deee8e18ea733a94c52a95
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What changed? Why?**
This PR does some nice cleanup:
- now we use `shikiji` to auto generate style for our codeblocks. Btw the component needs more polishing but at least now there is some automated color.
- set `color-scheme: dark;` at root, so we get some nice browser automated css set.
- fix a weird horizontal scroll with `overflow-x: hidden;`
- used the latest design to customize the connect wallet button.

**Notes to reviewers**
<img width="1332" alt="Screenshot 2024-01-02 at 3 52 00 PM" src="https://github.com/coinbase/build-onchain-apps/assets/829214/4e4fc244-114f-42f8-9094-288c3c9774c7">


**How has it been tested?**
