### PR TITLE
fix: next link console error

### DIFF
--- a/apps/build-onchain-apps/src/components/header/Navbar.tsx
+++ b/apps/build-onchain-apps/src/components/header/Navbar.tsx
@@ -3,13 +3,7 @@ import { ChevronDownIcon, GitHubLogoIcon } from '@radix-ui/react-icons';
 import * as NavigationMenu from '@radix-ui/react-navigation-menu';
 import { clsx } from 'clsx';
 import NextLink from 'next/link';
-import isClient from '../../utils/isClient';
 import styles from './Header.module.css';
-
-let originSite = '';
-if (isClient()) {
-  originSite = window.location.origin;
-}
 
 export function NavbarLink({
   href,
@@ -68,7 +62,7 @@ function Navbar() {
         </NavbarLink>
       </li>
       <li className="flex">
-        <NavbarLink href={`${originSite}/#get-started`}>Get Started</NavbarLink>
+        <NavbarLink href="/#get-started">Get Started</NavbarLink>
       </li>
       <li className="flex">
         <NavigationMenu.Root className="relative">


### PR DESCRIPTION
**What changed? Why?**

Removed unnecessary `originSite` that was causing this console error in the browser.

![image](https://github.com/coinbase/build-onchain-apps/assets/43140758/6cb4711d-589b-41d1-9c83-8dab8191dcf8)


**Notes to reviewers**

N/A

**How has it been tested?**

Locally
