### PR TITLE
fix: set metadataBase

### DIFF
--- a/template/src/utils/generateMetadata.test.ts
+++ b/template/src/utils/generateMetadata.test.ts
@@ -1,0 +1,38 @@
+import { generateMetadata } from './generateMetadata';
+
+describe('generateMetadata', () => {
+  it('should set metadataBase default', () => {
+    const metadata = generateMetadata({
+      title: 'Build Onchain Apps Toolkit',
+      description: 'Build Onchain Applications with the best consumer experience in a few minutes.',
+      images: 'themes.png',
+      pathname: '',
+    });
+    expect(metadata.metadataBase).toEqual(new URL('http://localhost:3000'));
+  });
+
+  const envs= [
+    ['BOAT_DEPLOY_URL', 'boat-deploy-url.com', 'https://boat-deploy-url.com'],
+    ['VERCEL_URL', 'vercel-url.com', 'https://vercel-url.com']
+  ];
+  describe.each(envs)('generateMetadata with different environment variables', (envVar, envValue, expectedUrl) => {
+  
+    it(`should set metadataBase from ${envVar}`, async () => {
+      envs.forEach(([v]) => delete process.env[v]);
+      process.env[envVar] = envValue;
+      jest.resetModules();
+  
+      const { generateMetadata: generateMetadata2 } = await import('./generateMetadata');
+      const metadata = generateMetadata2({
+        title: 'Build Onchain Apps Toolkit',
+        description: 'Build Onchain Applications with the best consumer experience in a few minutes.',
+        images: 'themes.png',
+        pathname: '',
+      });
+  
+      expect(metadata.metadataBase).toEqual(new URL(expectedUrl));
+    });
+  
+  });
+  
+});

--- a/template/src/utils/generateMetadata.test.ts
+++ b/template/src/utils/generateMetadata.test.ts
@@ -11,28 +11,29 @@ describe('generateMetadata', () => {
     expect(metadata.metadataBase).toEqual(new URL('http://localhost:3000'));
   });
 
-  const envs= [
+  const envs = [
     ['BOAT_DEPLOY_URL', 'boat-deploy-url.com', 'https://boat-deploy-url.com'],
-    ['VERCEL_URL', 'vercel-url.com', 'https://vercel-url.com']
+    ['VERCEL_URL', 'vercel-url.com', 'https://vercel-url.com'],
   ];
-  describe.each(envs)('generateMetadata with different environment variables', (envVar, envValue, expectedUrl) => {
-  
-    it(`should set metadataBase from ${envVar}`, async () => {
-      envs.forEach(([v]) => delete process.env[v]);
-      process.env[envVar] = envValue;
-      jest.resetModules();
-  
-      const { generateMetadata: generateMetadata2 } = await import('./generateMetadata');
-      const metadata = generateMetadata2({
-        title: 'Build Onchain Apps Toolkit',
-        description: 'Build Onchain Applications with the best consumer experience in a few minutes.',
-        images: 'themes.png',
-        pathname: '',
+  describe.each(envs)(
+    'generateMetadata with different environment variables',
+    (envVar, envValue, expectedUrl) => {
+      it(`should set metadataBase from ${envVar}`, async () => {
+        envs.forEach(([v]) => delete process.env[v]);
+        process.env[envVar] = envValue;
+        jest.resetModules();
+
+        const { generateMetadata: generateMetadata2 } = await import('./generateMetadata');
+        const metadata = generateMetadata2({
+          title: 'Build Onchain Apps Toolkit',
+          description:
+            'Build Onchain Applications with the best consumer experience in a few minutes.',
+          images: 'themes.png',
+          pathname: '',
+        });
+
+        expect(metadata.metadataBase).toEqual(new URL(expectedUrl));
       });
-  
-      expect(metadata.metadataBase).toEqual(new URL(expectedUrl));
-    });
-  
-  });
-  
+    },
+  );
 });

--- a/template/src/utils/generateMetadata.ts
+++ b/template/src/utils/generateMetadata.ts
@@ -8,6 +8,11 @@ type MetaTagsProps = {
   pathname: string;
 };
 
+const deployUrl = process.env.BOAT_DEPLOY_URL ?? process.env.VERCEL_URL;
+const defaultUrl = deployUrl
+  ? `https://${deployUrl}`
+  : `http://localhost:${process.env.PORT ?? 3000}`;
+
 export const generateMetadata = ({
   title = 'Build Onchain Apps',
   description = 'The easier way to build onchain apps.',
@@ -17,6 +22,7 @@ export const generateMetadata = ({
 }: MetaTagsProps): Metadata => {
   const i = Array.isArray(images) ? images : [images];
   return {
+    metadataBase: new URL(defaultUrl),
     title,
     description,
     openGraph: {


### PR DESCRIPTION
**What changed? Why?**
Explicitly sets metadataBase to suppress build warnings. From: https://github.com/coinbase/build-onchain-apps/issues/257

Added a `BOAT_DEPLOY_URL` env var to set the metadataBase value for build/deploy, otherwise falls back to `VERCEL_URL` or `http://localhost:3000` locally

**Notes to reviewers**


**How has it been tested?**
