### PR TITLE
Fix foundry-related configuration

### DIFF
--- a/template/contracts/.env.example
+++ b/template/contracts/.env.example
@@ -3,3 +3,4 @@ RPC_URL="https://sepolia.base.org"
 NETWORK="base_sepolia"
 SIGNATURE_MINT_SIGNER=
 BLOCK_EXPLORER_API_KEY="GET_API_KEY_FROM_THE_EXPLORER"
+BLOCK_EXPLORER="https://sepolia.basescan.org/"

--- a/template/contracts/foundry.toml
+++ b/template/contracts/foundry.toml
@@ -6,9 +6,9 @@ fs_permissions = [{ access = "read", path = "./"}]
 solc="0.8.23"
 
 [rpc_endpoints]
-"${NETWORK}"="${RPC_URL}"
+base_sepolia="${RPC_URL}"
 
 [etherscan]
-"${NETWORK}"={key="${BLOCK_EXPLORER_API_KEY}",url="${BLOCK_EXPLORER}"}
+base_sepolia={key="${BLOCK_EXPLORER_API_KEY}",url="${BLOCK_EXPLORER}"}
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/template/contracts/foundry.toml
+++ b/template/contracts/foundry.toml
@@ -6,7 +6,7 @@ fs_permissions = [{ access = "read", path = "./"}]
 solc="0.8.23"
 
 [rpc_endpoints]
-"${NETWORK}"="${RPC_URl}"
+"${NETWORK}"="${RPC_URL}"
 
 [etherscan]
 "${NETWORK}"={key="${BLOCK_EXPLORER_API_KEY}"}

--- a/template/contracts/foundry.toml
+++ b/template/contracts/foundry.toml
@@ -9,6 +9,6 @@ solc="0.8.23"
 "${NETWORK}"="${RPC_URL}"
 
 [etherscan]
-"${NETWORK}"={key="${BLOCK_EXPLORER_API_KEY}"}
+"${NETWORK}"={key="${BLOCK_EXPLORER_API_KEY}",url="${BLOCK_EXPLORER}"}
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config


### PR DESCRIPTION
**What changed? Why?**

1. Fix typo in `foundry.toml` file.
2. Add `url` param to Etherscan config as per [Foundry documentation](https://book.getfoundry.sh/reference/config/etherscan). Upon running `forge script script/BuyMeACoffee.s.sol --rpc-url base_sepolia` we'll get the following error: "At least one of 'url' or 'chain' must be present for Etherscan config with unknown alias 'base_sepolia'", hence adding the `url` of the explorer will fix it.
3. Use the `base_sepolia` alias directly in the TOML file instead of referencing it to avoid any errors.