### PR TITLE
chore: Support the user's system theme

### DIFF
--- a/template/src/providers/OnchainProviders.tsx
+++ b/template/src/providers/OnchainProviders.tsx
@@ -1,7 +1,12 @@
 'use client';
 
 import React, { ReactNode } from 'react';
-import { RainbowKitProvider, connectorsForWallets } from '@rainbow-me/rainbowkit';
+import {
+  RainbowKitProvider,
+  connectorsForWallets,
+  lightTheme,
+  darkTheme,
+} from '@rainbow-me/rainbowkit';
 import {
   metaMaskWallet,
   rainbowWallet,
@@ -62,7 +67,15 @@ const wagmiConfig = createConfig({
 function OnchainProviders({ children }: Props) {
   return (
     <WagmiConfig config={wagmiConfig}>
-      <RainbowKitProvider chains={chains}>{children}</RainbowKitProvider>
+      <RainbowKitProvider
+        chains={chains}
+        theme={{
+          lightMode: lightTheme(),
+          darkMode: darkTheme(),
+        }}
+      >
+        {children}
+      </RainbowKitProvider>
     </WagmiConfig>
   );
 }


### PR DESCRIPTION
**What changed? Why?**
Add support for using the user's preferred system theme (light/dark).

It's a jarring experience to open a big, white Connect modal when the system is set to dark theme.

Before (on dark mode)
<img width="1105" alt="Screenshot 2024-01-24 at 11 21 05 PM" src="https://github.com/coinbase/build-onchain-apps/assets/1104590/9d4bb3a3-fcc5-4664-a7f0-f7f55ca79c83">

After (on dark mode)
<img width="764" alt="Screenshot 2024-01-24 at 10 44 02 PM" src="https://github.com/coinbase/build-onchain-apps/assets/1104590/187e96d9-b486-4b30-b014-4c9e6c8b486f">


**Notes to reviewers**

**How has it been tested?**
Set your OS to light mode -> see light theme
Set your OS to dark mode -> see dark theme