### PR TITLE
Utility to see if a user can afford amount + utilize in FormBuyCoffee

### DIFF
--- a/template/src/hooks/useUserCanAfford.test.ts
+++ b/template/src/hooks/useUserCanAfford.test.ts
@@ -1,0 +1,45 @@
+import { useAccount, useBalance } from 'wagmi';
+import { useAddressCanAfford, useLoggedInUserCanAfford } from './useUserCanAfford';
+
+jest.mock('wagmi', () => ({
+  useBalance: jest.fn().mockReturnValue({ data: { value: 100n } }),
+  useAccount: jest.fn().mockReturnValue({ address: 1 }),
+}));
+
+describe('useAddressCanAfford', () => {
+  it('returns true if the address balance is greater than the amount', async () => {
+    useBalance.mockReturnValue({ data: { value: 100n } });
+
+    const result = useAddressCanAfford(1, 50n);
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false if the address balance is less than the amount', async () => {
+    useBalance.mockReturnValue({ data: { value: 50n } });
+
+    const result = useAddressCanAfford(1, 100n);
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('useLoggedInUserCanAfford', () => {
+  it('returns true if the logged in user balance is greater than the amount', async () => {
+    useAccount.mockReturnValue({ address: 1 });
+    useBalance.mockReturnValue({ data: { value: 100n } });
+
+    const result = useLoggedInUserCanAfford(50n);
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false if the logged in user balance is less than the amount', async () => {
+    useAccount.mockReturnValue({ address: 1 });
+    useBalance.mockReturnValue({ data: { value: 50n } });
+
+    const result = useLoggedInUserCanAfford(100n);
+
+    expect(result).toBe(false);
+  });
+});

--- a/template/src/hooks/useUserCanAfford.test.ts
+++ b/template/src/hooks/useUserCanAfford.test.ts
@@ -6,9 +6,12 @@ jest.mock('wagmi', () => ({
   useAccount: jest.fn().mockReturnValue({ address: 1 }),
 }));
 
+const mockedUseBalance = useBalance as jest.MockedFunction<typeof useBalance>;
+const mockedUseAccount = useAccount as jest.MockedFunction<typeof useAccount>;
+
 describe('useAddressCanAfford', () => {
   it('returns true if the address balance is greater than the amount', async () => {
-    useBalance.mockReturnValue({ data: { value: 100n } });
+    mockedUseBalance.mockReturnValue({ data: { value: 100n } });
 
     const result = useAddressCanAfford(1, 50n);
 
@@ -16,7 +19,7 @@ describe('useAddressCanAfford', () => {
   });
 
   it('returns false if the address balance is less than the amount', async () => {
-    useBalance.mockReturnValue({ data: { value: 50n } });
+    mockedUseBalance.mockReturnValue({ data: { value: 50n } });
 
     const result = useAddressCanAfford(1, 100n);
 
@@ -26,8 +29,8 @@ describe('useAddressCanAfford', () => {
 
 describe('useLoggedInUserCanAfford', () => {
   it('returns true if the logged in user balance is greater than the amount', async () => {
-    useAccount.mockReturnValue({ address: 1 });
-    useBalance.mockReturnValue({ data: { value: 100n } });
+    mockedUseAccount.mockReturnValue({ address: 1 });
+    mockedUseBalance.mockReturnValue({ data: { value: 100n } });
 
     const result = useLoggedInUserCanAfford(50n);
 
@@ -35,8 +38,8 @@ describe('useLoggedInUserCanAfford', () => {
   });
 
   it('returns false if the logged in user balance is less than the amount', async () => {
-    useAccount.mockReturnValue({ address: 1 });
-    useBalance.mockReturnValue({ data: { value: 50n } });
+    mockedUseAccount.mockReturnValue({ address: 1 });
+    mockedUseBalance.mockReturnValue({ data: { value: 50n } });
 
     const result = useLoggedInUserCanAfford(100n);
 

--- a/template/src/hooks/useUserCanAfford.ts
+++ b/template/src/hooks/useUserCanAfford.ts
@@ -1,0 +1,29 @@
+import { useAccount, useBalance } from 'wagmi';
+
+/**
+ * Utility to see if an address balance can afford to transact for a certain amount
+ *
+ * @param address address of user to check balance for
+ * @param amount amount to check if user can afford
+ * @returns {boolean}
+ */
+export function useAddressCanAfford(address: number, amount: bigint) {
+  const result = useBalance({
+    address,
+  });
+
+  return amount <= result.data.value;
+}
+
+/**
+ * Utility to see if the current logged in user can afford to transact for a certain amount
+ *
+ * @param address address of user to check balance for
+ * @param amount amount to check if user can afford
+ * @returns {boolean}
+ */
+export function useLoggedInUserCanAfford(amount: bigint) {
+  const account = useAccount();
+
+  return useAddressCanAfford(account.address, amount);
+}

--- a/template/src/hooks/useUserCanAfford.ts
+++ b/template/src/hooks/useUserCanAfford.ts
@@ -7,10 +7,12 @@ import { useAccount, useBalance } from 'wagmi';
  * @param amount amount to check if user can afford
  * @returns {boolean}
  */
-export function useAddressCanAfford(address: number, amount: bigint) {
+export function useAddressCanAfford(address: `0x${string}`, amount: bigint) {
   const result = useBalance({
     address,
   });
+
+  if (!result.data) return false;
 
   return amount <= result.data.value;
 }
@@ -25,5 +27,5 @@ export function useAddressCanAfford(address: number, amount: bigint) {
 export function useLoggedInUserCanAfford(amount: bigint) {
   const account = useAccount();
 
-  return useAddressCanAfford(account.address, amount);
+  return useAddressCanAfford(account.address as `0x${string}`, amount);
 }

--- a/template/src/pageComponents/buy-me-coffee/FormBuyCoffee.tsx
+++ b/template/src/pageComponents/buy-me-coffee/FormBuyCoffee.tsx
@@ -10,7 +10,7 @@ type FormBuyCoffeeProps = {
   onComplete: () => void;
 };
 
-const BUY_COFFEE_AMOUNT_RAW = '0.5';
+const BUY_COFFEE_AMOUNT_RAW = '0.0001';
 const BUY_COFFEE_AMOUNT = parseEther(BUY_COFFEE_AMOUNT_RAW);
 
 function FormBuyCoffee({ onComplete }: FormBuyCoffeeProps) {

--- a/template/src/pageComponents/buy-me-coffee/FormBuyCoffee.tsx
+++ b/template/src/pageComponents/buy-me-coffee/FormBuyCoffee.tsx
@@ -17,7 +17,7 @@ type FormBuyCoffeeProps = {
 };
 
 const BUY_COFFEE_AMOUNT_RAW = '0.5';
-const BUY_COFFEE_AMOUNT = parseEther('0.5');
+const BUY_COFFEE_AMOUNT = parseEther(BUY_COFFEE_AMOUNT_RAW);
 
 function FormBuyCoffee({ onComplete }: FormBuyCoffeeProps) {
   // Component state

--- a/template/src/pageComponents/buy-me-coffee/FormBuyCoffee.tsx
+++ b/template/src/pageComponents/buy-me-coffee/FormBuyCoffee.tsx
@@ -115,7 +115,7 @@ function FormBuyCoffee({ onComplete }: FormBuyCoffeeProps) {
         Send 1 Coffee for 0.001ETH
       </button>
     );
-  }, [areInputsDisabled, contract.status, contract.supportedChains]);
+  }, [areInputsDisabled, contract.status, contract.supportedChains, canAfford]);
 
   return (
     <form onSubmit={handleSubmit} className="w-full">

--- a/template/src/pageComponents/buy-me-coffee/FormBuyCoffee.tsx
+++ b/template/src/pageComponents/buy-me-coffee/FormBuyCoffee.tsx
@@ -31,7 +31,7 @@ function FormBuyCoffee({ onComplete }: FormBuyCoffeeProps) {
     functionName: 'buyCoffee',
     args: [name, message],
     enabled: name !== '' && message !== '' && contract.status === 'ready',
-    value: parseEther('0.001'),
+    value: BUY_COFFEE_AMOUNT,
     onSuccess(data) {
       console.log('Success prepare buyCoffee', data);
     },

--- a/template/src/pageComponents/buy-me-coffee/FormBuyCoffee.tsx
+++ b/template/src/pageComponents/buy-me-coffee/FormBuyCoffee.tsx
@@ -2,14 +2,8 @@ import React, { useState, useCallback, useMemo } from 'react';
 
 import clsx from 'clsx';
 import { parseEther } from 'viem';
-import {
-  useAccount,
-  useContractWrite,
-  usePrepareContractWrite,
-  useWaitForTransaction,
-} from 'wagmi';
+import { useContractWrite, usePrepareContractWrite, useWaitForTransaction } from 'wagmi';
 import { useBuyMeACoffeeContract } from '../../hooks/contracts';
-import { useBalance } from 'wagmi';
 import { useLoggedInUserCanAfford } from '../../hooks/useUserCanAfford';
 
 type FormBuyCoffeeProps = {


### PR DESCRIPTION
**What changed? Why?**
- New utility for `useAddressCanAfford`
- New utility for `useLoggedInUserCanAfford`
- Unit tests for both
- Utilize above utilities to adjust UX if a user cannot afford to buy coffee

**Notes to reviewers**
## Before
If a user  would be allowed to initiate a transaction, which would lead to a failure of transaction, without notifying the user

## After
The UX adjusts accordingly
![Screenshot 2024-01-27 at 9 07 29 AM](https://github.com/coinbase/build-onchain-apps/assets/4120754/eb6c8ed0-07c5-4b64-b0d6-303bfd9e50d6)


**How has it been tested?**

- Visit `/buy-me-coffee` with an account that has > 0.5ETH on Base Sepolia. User should be able to buy coffee
- Visit `/buy-me-coffee` with an account that has < 0.5ETH on Base Sepolia. User should **not** be able to buy coffee


