### PR TITLE
Update and Patched Improper Input Validation improperly handles URLs in the url.parse() function

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4153,12 +4153,12 @@ __metadata:
   linkType: hard
 
 "follow-redirects@npm:^1.15.0":
-  version: 1.15.3
-  resolution: "follow-redirects@npm:1.15.3"
+  version: 1.15.5
+  resolution: "follow-redirects@npm:1.15.5"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 915a2cf22e667bdf47b1a43cc6b7dce14d95039e9bbf9a24d0e739abfbdfa00077dd43c86d4a7a19efefcc7a99af144920a175eedc3888d268af5df67c272ee5
+  checksum: 418d71688ceaf109dfd6f85f747a0c75de30afe43a294caa211def77f02ef19865b547dfb73fde82b751e1cc507c06c754120b848fe5a7400b0a669766df7615
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

## Description Overview
Affected of this project `coinbase/build-onchain-apps` are vulnerable to Improper Input Validation due to the improper handling of URLs by the `url.parse()` function. When new `URL()` throws an error, it can be manipulated to misinterpret the hostname. An attacker could exploit this weakness to redirect traffic to a malicious site, potentially leading to information disclosure, phishing attacks, or other security breaches.


**PoC:**
```js
# Case 1 : Bypassing localhost restriction
let url = 'http://[localhost]/admin';
try{
    new URL(url); // ERROR : Invalid URL
}catch{
    url.parse(url); // -> http://localhost/admin
}

# Case 2 : Bypassing domain restriction
let url = 'http://attacker.domain*.allowed.domain:a';
try{
    new URL(url); // ERROR : Invalid URL
}catch{
    url.parse(url); // -> http://attacker.domain/*.allowed.domain:a
}
```
Below is part of `follow-redirects's` .js code.
```js
function urlToOptions(urlObject) {
  var options = {
    protocol: urlObject.protocol,
    hostname: urlObject.hostname.startsWith("[") ?
      /* istanbul ignore next */
      urlObject.hostname.slice(1, -1) :
      urlObject.hostname,
    hash: urlObject.hash,
    search: urlObject.search,
    pathname: urlObject.pathname,
    path: urlObject.pathname + urlObject.search,
    href: urlObject.href,
  };
  if (urlObject.port !== "") {
    options.port = Number(urlObject.port);
  }
  return options;
}
```
It checks URL hostname which is startswith `[` character. Which means if the urlObject is `http://[localhost]/`, then it converts to `http://localhost/`.

The problem comes from below code.
```
    function request(input, options, callback) {
      // Parse parameters
      if (isString(input)) {
        var parsed;
        try {
          parsed = urlToOptions(new URL(input));
        }
        catch (err) {
          /* istanbul ignore next */
          parsed = url.parse(input);
        }
    /* below code skipped */
```
`urlToOptions()` function is called after new URL().

When new `URL('http://[localhost]')` it throws an error which is Invalid URL. Then it goes `catch{ }` phrase.

At the `catch{ }` phrase, there is vulnerable function which is `url.parse()`.

`url.parse('http://[localhost]')` sees URL to `http://localhost`.

## Proof of Concept
```js
// PoC.js
const express = require("express");
const http = require('follow-redirects').http;
const app  = express();
const port = 80;

const isLocalhost = function (url) {
    try{
        u = new URL(url);
        if(u.hostname.includes('localhost')
        || u.hostname.includes('127.0.0.1')
        ){
            return true;
        }
    }catch{}
    return false;
}
app.use(express.json())

app.get("/", (req, res) => {
    res.send("Hello World");
})

app.post("/request", (req, res) => {
    let url = req.body.url;
    let options = {
        'followRedirects':false
    }
    if(req.body?.url){
        if(isLocalhost(req.body.url)){
            res.send('Localhost is restricted.');
            return;
        };
        http.get(url, options, (response) => {
            let data = '';
            response.on('data', chunk => {
                data += chunk.toString();
            });
            response.on('end', () => {
                res.send(data);
            })
        }).on('error', (e) => {
            console.log(e);
            res.status(500).send('Server Error');
        })
    }else{
        res.send('URL is required.');
    }
})

app.get("/admin", (req, res) => {
    if(req.socket.remoteAddress.includes('127.0.0.1')){
        res.send('Admin Page');
    }else{
        res.status(404).send('Not Found');
    }
})

app.listen(port, () => {
    console.log(`App listening on port ${port}`)
})
```
CWE-20
CWE-601
`CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N`

**What changed? Why?**


**Notes to reviewers**


**How has it been tested?**
