### PR TITLE
fix: Incorrect Mint Step feedback

### DIFF
--- a/template/src/pageComponents/mint/ContractDemo.tsx
+++ b/template/src/pageComponents/mint/ContractDemo.tsx
@@ -16,7 +16,7 @@ export enum MintSteps {
 }
 
 export default function MintContractDemo() {
-  const [mintStep, setMintStep] = useState<MintSteps | null>(null);
+  const [mintStep, setMintStep] = useState<MintSteps>(MintSteps.START_MINT_STEP);
 
   const { chain } = useAccount();
 

--- a/template/src/pageComponents/mint/steps/MintCompleteStep.tsx
+++ b/template/src/pageComponents/mint/steps/MintCompleteStep.tsx
@@ -4,13 +4,13 @@ import Button from '../../../components/Button/Button';
 import { MintSteps } from '../ContractDemo';
 
 type MintCompleteStepProps = {
-  setMintStep: React.Dispatch<React.SetStateAction<MintSteps | null>>;
+  setMintStep: React.Dispatch<React.SetStateAction<MintSteps>>;
   collectionName: string | null;
 };
 
 export default function MintCompleteStep({ setMintStep, collectionName }: MintCompleteStepProps) {
   const handleMintAnother = useCallback(() => {
-    setMintStep(null);
+    setMintStep(MintSteps.START_MINT_STEP);
   }, [setMintStep]);
 
   return (

--- a/template/src/pageComponents/mint/steps/OutOfGasStep.tsx
+++ b/template/src/pageComponents/mint/steps/OutOfGasStep.tsx
@@ -4,12 +4,12 @@ import Button from '../../../components/Button/Button';
 import { MintSteps } from '../ContractDemo';
 
 type OutOfGasStepProps = {
-  setMintStep: React.Dispatch<React.SetStateAction<MintSteps | null>>;
+  setMintStep: React.Dispatch<React.SetStateAction<MintSteps>>;
 };
 
 export default function OutOfGasStep({ setMintStep }: OutOfGasStepProps) {
   const handleGotIt = useCallback(() => {
-    setMintStep(null);
+    setMintStep(MintSteps.START_MINT_STEP);
   }, [setMintStep]);
 
   return (

--- a/template/src/pageComponents/mint/steps/StartMintStep.tsx
+++ b/template/src/pageComponents/mint/steps/StartMintStep.tsx
@@ -16,8 +16,8 @@ import MintProcessingStep from './MintProcessingStep';
 import OutOfGasStep from './OutOfGasStep';
 
 type StartMintProps = {
-  setMintStep: React.Dispatch<React.SetStateAction<MintSteps | null>>;
-  mintStep: MintSteps | null;
+  setMintStep: React.Dispatch<React.SetStateAction<MintSteps>>;
+  mintStep: MintSteps;
   collectionName: string | null;
 };
 
@@ -53,15 +53,11 @@ export default function StartMintStep({ setMintStep, mintStep, collectionName }:
       setMintStep(MintSteps.MINT_COMPLETE_STEP);
     }
 
-    if (transactionStatus === 'error') {
-      if (
+    if (errorMint) {
+      const isOutOfGas =
         errorMint instanceof TransactionExecutionError &&
-        errorMint.message.toLowerCase().includes('out of gas')
-      ) {
-        setMintStep(MintSteps.OUT_OF_GAS_STEP);
-      } else {
-        setMintStep(null);
-      }
+        errorMint.message.toLowerCase().includes('out of gas');
+      setMintStep(isOutOfGas ? MintSteps.OUT_OF_GAS_STEP : MintSteps.START_MINT_STEP);
     }
   }, [transactionStatus, setMintStep, errorMint]);
 
@@ -74,13 +70,13 @@ export default function StartMintStep({ setMintStep, mintStep, collectionName }:
 
   return (
     <>
-      {mintStep === MintSteps.START_MINT_STEP && <MintProcessingStep />}
+      {mintStep === MintSteps.MINT_PROCESSING_STEP && <MintProcessingStep />}
       {mintStep === MintSteps.OUT_OF_GAS_STEP && <OutOfGasStep setMintStep={setMintStep} />}
       {mintStep === MintSteps.MINT_COMPLETE_STEP && (
         <MintCompleteStep setMintStep={setMintStep} collectionName={collectionName} />
       )}
 
-      {mintStep === null && (
+      {mintStep === MintSteps.START_MINT_STEP && (
         <Button
           buttonContent="Mint"
           onClick={handleMint}


### PR DESCRIPTION
**What changed? Why?**
- Error such as user rejecting a wallet popup was not resetting state back
- Incorrect condition was used to display in Progress state
- Using MintSteps.START_MINT_STEP as default state instead of null

**Notes to reviewers**


**How has it been tested?**
- `yarn test`
- `manual testing`