### PR TITLE
fix: notConnected behaviour after moving to wagmi 2.0

### DIFF
--- a/template/src/hooks/contracts.test.ts
+++ b/template/src/hooks/contracts.test.ts
@@ -37,18 +37,22 @@ describe('contracts', () => {
     });
 
     it.each([
-      ['notConnected', undefined, undefined],
-      ['onUnsupportedNetwork', { id: 31337 }, undefined],
-      ['ready', { id: baseSepolia.id }, '0xbaseSepolia'],
-    ])('handles %s state', (state, chain, address) => {
-      mockUseAccount.mockImplementation(() => ({ chain: chain }) as ReturnType<typeof useAccount>);
+      ['notConnected', undefined, undefined, undefined],
+      ['notConnected', undefined, '0xbaseSepolia', undefined],
+      ['notConnected', { id: 31337 }, undefined, undefined],
+      ['onUnsupportedNetwork', { id: 31337 }, undefined, '0x123'],
+      ['ready', { id: baseSepolia.id }, '0xbaseSepolia', '0x123'],
+    ])('handles %s state', (state, chain, address, userAccount) => {
+      mockUseAccount.mockImplementation(
+        () => ({ chain: chain, isConnected: !!userAccount }) as ReturnType<typeof useAccount>,
+      );
       const {
         result: { current },
       } = renderHook(() => useTestContract());
       expect(current.status).toBe(state);
       expect(current.abi).toEqual(BuyMeACoffeeABI);
       expect(current.supportedChains).toEqual([baseSepolia]);
-      if (address) {
+      if (address && !!userAccount) {
         expect(current).toEqual(expect.objectContaining({ address }));
       } else {
         expect(current).not.toHaveProperty('address');

--- a/template/src/hooks/contracts.ts
+++ b/template/src/hooks/contracts.ts
@@ -1,4 +1,4 @@
-import { Abi, type Chain } from 'viem';
+import { Abi, Address, type Chain } from 'viem';
 import { baseSepolia } from 'viem/chains';
 import { useAccount } from 'wagmi';
 import BuyMeACoffeeABI from '../contract/BuyMeACoffee';
@@ -7,12 +7,12 @@ import SignatureMint721ABI from '../contract/SignatureMint721';
 
 type ContractInstance = {
   chain: Chain;
-  address: `0x${string}`;
+  address: Address;
   deactivated?: boolean;
 };
 
 type UseContractReturn<T extends Abi> = { abi: T; supportedChains: Chain[] } & (
-  | { address: `0x${string}`; status: 'ready' }
+  | { address: Address; status: 'ready' }
   | { status: 'onUnsupportedNetwork' }
   | { status: 'notConnected' }
   | { status: 'deactivated' }
@@ -28,14 +28,14 @@ type Spec<T extends Abi> = {
  */
 export function generateContractHook<T extends Abi>({ abi, ...spec }: Spec<T>) {
   function useContract(): UseContractReturn<typeof abi> {
-    const { chain } = useAccount();
+    const { chain, isConnected } = useAccount();
     const supportedChains = Object.values(spec).map((s) => s.chain);
 
-    if (!chain) {
+    if (!isConnected) {
       return { abi, status: 'notConnected', supportedChains };
     }
 
-    if (chain.id in spec) {
+    if (chain && chain.id in spec) {
       if (spec[chain.id].deactivated) {
         return { abi, status: 'deactivated', supportedChains };
       }


### PR DESCRIPTION
**What changed? Why?**

Prior to wagmi 2.0 `useChain` hook was used to determine if correct chain is connected as well as to check if wallet is connected. In wagmi 2.0 the hook was replaced with useAccount and behaviour slightly changed, with a correct way to detect unconnected wallet to check for isConnected property. And `chain` will can still be returned if user haven't connected his account to the dapp


**Notes to reviewers**


**How has it been tested?**

`yarn test`
`manual testing`