### PR TITLE
fix: add noopener and noreferrer when opening external link

### DIFF
--- a/template/web/src/components/layout/guide/A.tsx
+++ b/template/web/src/components/layout/guide/A.tsx
@@ -1,6 +1,6 @@
 export default function A({ href, children }: { href: string; children: React.ReactNode }) {
   return (
-    <a href={href} target="_blank" className="text-blue-500 no-underline">
+    <a target="_blank" rel="noopener noreferrer" href={href} className="text-blue-500 no-underline">
       {children}
     </a>
   );


### PR DESCRIPTION
**What changed? Why?**
add `noopener` and `noreferrer` when opening external link

**Notes to reviewers**


**How has it been tested?**
