### PR TITLE
fix: Update Paymaster URL environment variable. 

### DIFF
--- a/.changeset/rare-shirts-flow.md
+++ b/.changeset/rare-shirts-flow.md
@@ -1,0 +1,5 @@
+---
+'@coinbase/build-onchain-apps': patch
+---
+
+- **fix**: Update Paymaster URL environment variable. By @cpcramer

--- a/template/web/app/paymaster-bundler/_components/PaymasterBundlerDemo.tsx
+++ b/template/web/app/paymaster-bundler/_components/PaymasterBundlerDemo.tsx
@@ -8,13 +8,13 @@ import { CallStatus } from './CallStatus';
 
 // Use the local API URL to target the Paymaster directly without a proxy
 // if running on localhost, otherwise use the Paymaster Proxy.
-const paymasterURL = process.env.NEXT_PRIVATE_PAYMASTER_URL;
+const paymasterURL = process.env.NEXT_PUBLIC_PAYMASTER_URL;
 const isLocalEnv = isLocal();
 const defaultUrl = isLocalEnv ? paymasterURL : `${document.location.origin}/api/paymaster-proxy`;
 
 export default function PaymasterBundlerDemo() {
   const { address } = useAccount();
-  const { data: transactionID, writeContracts } = useWriteContracts();
+  const { data: callID, writeContracts } = useWriteContracts();
   const contract = usePaymasterBundlerContract();
 
   if (contract.status !== 'ready') {
@@ -76,12 +76,7 @@ export default function PaymasterBundlerDemo() {
         >
           Mint NFT
         </button>
-        {transactionID && <CallStatus id={transactionID} />}
-        {transactionID && (
-          <div className={clsx('mt-4 overflow-x-auto rounded-lg bg-gray-800 p-4 text-lg')}>
-            <strong>Transaction ID:</strong> <span className="break-all">{transactionID}</span>
-          </div>
-        )}
+        {callID && <CallStatus id={callID} />}
       </section>
     </div>
   );

--- a/template/web/src/utils/paymasterClient.ts
+++ b/template/web/src/utils/paymasterClient.ts
@@ -3,7 +3,7 @@ import { paymasterActionsEip7677 } from 'permissionless/experimental';
 import { createClient, http } from 'viem';
 import { baseSepolia } from 'viem/chains';
 
-const paymasterService = process.env.NEXT_PRIVATE_PAYMASTER_URL ?? '';
+const paymasterService = process.env.NEXT_PUBLIC_PAYMASTER_URL ?? '';
 
 export const paymasterClient = createClient({
   chain: baseSepolia,


### PR DESCRIPTION
**What changed? Why?**
Update PaymasterURL from `NEXT_PRIVATE_PAYMASTER_URL` to `NEXT_PUBLIC_PAYMASTER_URL`.
- There were two issues here. First, we are accessing this environment variable on the client side, in Nextjs applications environment variables with the `NEXT_PRIVATE` prefix are not available. Therefore we were returning `undefined`. The second issue was that our production paymaster url was incorrect, and was actually a Base paymaster url rather than the intended CDP paymaster url. 

- Updated the `transactionID` to `callID`. This is a different ID that we were mistakingly calling the transaction id. It's the call id, which is what CallStatus uses the call id to fetch and display the status of a writeContracts call.

Tested locally and in dev:
<img width="422" alt="Screenshot 2024-06-01 at 1 57 26 PM" src="https://github.com/coinbase/build-onchain-apps/assets/39774249/1d042768-7e0e-4ba0-8f6c-1745319c9953">

Confirmed that we are using the CDP paymaster:
<img width="1388" alt="Screenshot 2024-06-01 at 1 58 28 PM" src="https://github.com/coinbase/build-onchain-apps/assets/39774249/18c109ed-8219-498c-995a-4feeeb23f993">

**Notes to reviewers**


**How has it been tested?**
