### PR TITLE
Fix: Deprecation Warnings fetchPriority Prop and ReactDOMTestUtils.act  #508

### DIFF
--- a/template/web/src/components/layout/banner/banner.tsx
+++ b/template/web/src/components/layout/banner/banner.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import Image from 'next/image';
 import NextLink from 'next/link';
 
 type BannerProps = {
@@ -20,7 +19,7 @@ export default function Banner({ pageName, pageUrl, wip }: BannerProps) {
     >
       <div className="flex items-start justify-start gap-2 md:gap-6">
         <div className="flex h-6 w-6 shrink-0 items-center justify-center md:h-12 md:w-12">
-          <Image
+          <img
             src="/hammerandpick.svg"
             width={10}
             height={10}

--- a/template/web/src/hooks/test/useDebounce.test.ts
+++ b/template/web/src/hooks/test/useDebounce.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import { renderHook } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
+import { act } from 'react';
 import { useDebounce } from '../useDebounce';
 
 describe('useDebounce', () => {


### PR DESCRIPTION
**What changed? Why?**

**1.fetchPriority prop:**
- Replaced the `Image` tag of Next.js with a standard `img` tag in `src/components/layout/banner/banner.tsx`
- Reason: To address the warning: `React does not recognize the fetchPriority prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase fetchpriority instead.`

**2.ReactDOMTestUtils.act:**
- Updated the import statement to import `act` from `react` in `src/hooks/test/useDebounce.test.ts`
- Reason: To address the `warning: ReactDOMTestUtils.act is deprecated in favor of React.act. Import act from react instead of react-dom/test-utils`

**Notes to reviewers**
- The changes are aimed at resolving specific deprecation warnings during test execution.
- No other functional changes were made to the components or tests.
- The tests were run after making these changes to ensure no new issues were introduced.

**How has it been tested?**

**Steps to Reproduce:**

1.Clone the repository:

```bash
git clone https://github.com/your-username/build-onchain-apps.git
cd build-onchain-apps
```
2.Navigate to the project directory:
```bash
cd template/web/app
```
3.Install the dependencies:
```bash
npm install
```
4.Run the tests:
```bash
npm run test
```
**Expected Behavior**
No deprecation warnings should appear.

**Actual Behavior (Before Fix)**
1.
![1](https://github.com/coinbase/build-onchain-apps/assets/69946307/3c3304e8-9bbd-41a0-9c93-583117e06e32)
2.
![2](https://github.com/coinbase/build-onchain-apps/assets/69946307/6751930f-da6a-4ed9-b030-5db5aa83ce3f)


**Actual Behavior (After Fix):**
- The warnings are no longer displayed during the test run.
- All tests pass successfully.
![3](https://github.com/coinbase/build-onchain-apps/assets/69946307/867662fc-3541-4f2a-8eff-6d57c0f1e26c)



