### PR TITLE
add message pagination to the buy me a coffee dapp so you can read all messages, not just the first 8

### DIFF
--- a/template/web/app/buy-me-coffee/_components/ContractDemo.tsx
+++ b/template/web/app/buy-me-coffee/_components/ContractDemo.tsx
@@ -1,10 +1,13 @@
 import { clsx } from 'clsx';
+import Button from '@/components/Button/Button';
 import useOnchainCoffeeMemos from '../_hooks/useOnchainCoffeeMemos';
 import FormBuyCoffee from './FormBuyCoffee';
 import Memos from './Memos';
 
 export default function BuyMeCoffeeContractDemo() {
-  const { memos, refetchMemos } = useOnchainCoffeeMemos();
+  const pageSize = 5;
+  const { memos, refetchMemos, currentPage, goToPreviousPage, goToNextPage } =
+    useOnchainCoffeeMemos(pageSize);
 
   return (
     <div
@@ -22,6 +25,23 @@ export default function BuyMeCoffeeContractDemo() {
         <h2 className="mb-5 w-fit text-2xl font-semibold text-white">Messages from supporters</h2>
 
         {memos?.length > 0 && <Memos memos={memos} />}
+        <div className="mt-4 flex flex items-center justify-between">
+          <Button
+            className="w-auto px-10"
+            onClick={goToPreviousPage}
+            disabled={currentPage < 1}
+            buttonContent={<span>Read older messages</span>}
+          />
+
+          <div>Page {currentPage + 1}</div>
+
+          <Button
+            className="w-auto px-10"
+            onClick={goToNextPage}
+            disabled={memos.length < pageSize}
+            buttonContent={<span>Read newer messages</span>}
+          />
+        </div>
       </section>
       <aside>
         <div

--- a/template/web/app/buy-me-coffee/_components/Memos.tsx
+++ b/template/web/app/buy-me-coffee/_components/Memos.tsx
@@ -16,22 +16,19 @@ function Memos({ memos }: MemosProps) {
   }
   return (
     <ul className="flex w-full flex-col items-center gap-10">
-      {memos
-        .map((memo) => {
-          return (
-            <MemoCard
-              key={memo.time.toString()}
-              numCoffees={memo.numCoffees}
-              userName={memo.userName}
-              twitterHandle={memo.twitterHandle}
-              message={memo.message}
-              userAddress={memo.userAddress}
-              time={memo.time}
-            />
-          );
-        })
-        .reverse()
-        .slice(0, 8)}
+      {memos.map((memo) => {
+        return (
+          <MemoCard
+            key={memo.time.toString()}
+            numCoffees={memo.numCoffees}
+            userName={memo.userName}
+            twitterHandle={memo.twitterHandle}
+            message={memo.message}
+            userAddress={memo.userAddress}
+            time={memo.time}
+          />
+        );
+      })}
     </ul>
   );
 }

--- a/template/web/app/buy-me-coffee/_hooks/useOnchainCoffeeMemos.ts
+++ b/template/web/app/buy-me-coffee/_hooks/useOnchainCoffeeMemos.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { useReadContract } from 'wagmi';
 import { markStep } from '@/utils/analytics';
 import { useBuyMeACoffeeContract } from '../_contracts/useBuyMeACoffeeContract';
@@ -7,27 +7,42 @@ import type { CoffeeMemo } from '../_components/types';
 /**
  * Hooks is abstracting away the logic of calling a read-only function on a contract.
  * offers a refetch function to refetch the data.
- * @returns The memos and a function to refetch them.
+ * @returns The memos, a function to refetch them, and paging functions.
  */
-function useOnchainCoffeeMemos() {
+function useOnchainCoffeeMemos(pageSize: number = 5) {
   const contract = useBuyMeACoffeeContract();
+  const [currentPage, setCurrentPage] = useState(0);
+
+  const fetchMemosArgs: [bigint, bigint] = [BigInt(currentPage * pageSize), BigInt(pageSize)];
 
   markStep('useReadContract.refetchMemos');
   const contractReadResult = useReadContract({
     address: contract.status === 'ready' ? contract.address : undefined,
     abi: contract.abi,
     functionName: 'getMemos',
-    args: [BigInt(0), BigInt(25)], // TODO : Implement Paging
+    args: fetchMemosArgs,
   });
   markStep('useReadContract.refetchMemos');
+
+  const goToNextPage = useCallback(() => {
+    setCurrentPage((prevPage) => prevPage + 1);
+  }, []);
+
+  const goToPreviousPage = useCallback(() => {
+    setCurrentPage((prevPage) => (prevPage > 0 ? prevPage - 1 : 0));
+  }, []);
 
   return useMemo(
     () => ({
       memos:
         contractReadResult.status === 'success' ? (contractReadResult.data as CoffeeMemo[]) : [],
       refetchMemos: contractReadResult.refetch,
+      currentPage,
+      goToNextPage,
+      goToPreviousPage,
+      pageSize,
     }),
-    [contractReadResult],
+    [contractReadResult, currentPage, goToNextPage, goToPreviousPage],
   );
 }
 


### PR DESCRIPTION
**What changed? Why?**

I forked the repo to build and noticed a comment that had a "pagination TODO" in the buy-me-coffee app. I was implementing pagination in my fork anyway, so I figured the based thing to do is also commit it to BOAT. [Video demo](https://www.loom.com/share/722b3e03d3994cb68b819c1dd738fd84) 


## Pagination

<img width="928" alt="Screenshot 2024-06-10 at 6 22 30 PM" src="https://github.com/coinbase/build-onchain-apps/assets/91382964/da618d69-5a12-439a-82be-ed78b21da77c">

✅ Page size is configurable and set to 5 so that the Guide is still relatively close to the fold
✅ Current page displayed
✅ Read older messages button is disabled if you're on the first page
✅ Read newer messages button is disabled if there are no newer records

**Notes to reviewers**

Unfortunately the smart contract doesn't return the number of messages / memos, there's no good way of knowing the total without starting at 0 and counting up to the end, so messages go from oldest to newest rather than newest to oldest, which would be more ideal.

If the smart contract is refactored, you can reuse most of my pagination solution ☺️

**How has it been tested?**

Tested on by creating a new BOAT app with this version of the template on localhost - Video demo: [pagination of messages in buy-me-coffee](https://www.loom.com/share/722b3e03d3994cb68b819c1dd738fd84) 
