### PR TITLE
chore: add `JSDoc` type to `prettier` config

### DIFF
--- a/.changeset/early-students-confess.md
+++ b/.changeset/early-students-confess.md
@@ -1,0 +1,5 @@
+---
+'@coinbase/build-onchain-apps': patch
+---
+
+chore: add JSDoc annotation to prettier config file

--- a/template/web/prettier.config.js
+++ b/template/web/prettier.config.js
@@ -1,3 +1,4 @@
+/** @type {import("prettier").Config} */
 module.exports = {
   arrowParens: 'always',
   bracketSameLine: false,


### PR DESCRIPTION
This PR adds JSDoc type to the prettier config so users using the `web` template can now have intellisense.

https://github.com/coinbase/build-onchain-apps/assets/155655425/c9d990e7-9236-4e73-94df-a289646f4bb6