### PR TITLE
Fix typos in README.md files

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -56,7 +56,7 @@ A deploy script `AllowlistNFT.s.sol` is provided. Please be sure to update all o
 6. `allowlistPrice`: The price of an allowlist mint.
 7. `allowlistOpen`: The timestamp in which allowlist mint begins.
 8. `allowlistClose`: The timestamp in which allowlist mint ends. Note: Public mint will begin immediately after `allowlistClose`.
-9. `maxAllowlistMint`: The maximum number of NFTs a allowlisted address can allowlist mint.
+9. `maxAllowlistMint`: The maximum number of NFTs an allowlisted address can allowlist mint.
 10. `maxPublicMint`: The maximum number of NFTs an address can public mint.
 11. `uri`: The base URI of your NFT. This is your IPFS hash.
 

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -53,7 +53,7 @@ A deploy script `AllowlistNFT.s.sol` is provided. Please be sure to update all o
 3. `allowlistRoot`: The allowlist root generated for your allowlisted addresses. For information on generating merkle roots for allowlists, you can read about this in-depth guide [here](https://medium.com/@ItsCuzzo/using-merkle-trees-for-nft-allowlists-523b58ada3f9)
 4. `maxSupply`: The maximum number of NFTs in your collection.
 5. `price`: The price of a public mint.
-6. `allowlistPrice`: The price of a allowlist mint.
+6. `allowlistPrice`: The price of an allowlist mint.
 7. `allowlistOpen`: The timestamp in which allowlist mint begins.
 8. `allowlistClose`: The timestamp in which allowlist mint ends. Note: Public mint will begin immediately after `allowlistClose`.
 9. `maxAllowlistMint`: The maximum number of NFTs a allowlisted address can allowlist mint.

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -38,7 +38,7 @@ It also contains a sample implementation (`CustomERC1155.sol`) of ERC1155 using 
 
 #### AllowlistNFT
 
-Contract that allows a user to mint a ERC721A either from a allowlist or from a public mint. This is useful for mints where you want to allow specified users to have early access and (optionally) a lower mint price. After your defined allowlist window ends, the public mint will begin immediately. This contract uses [ERC721A](https://github.com/chiru-labs/ERC721A) as base to allow for more efficient minting of multiple NFTs in a single transaction.
+Contract that allows a user to mint an ERC721A either from a allowlist or from a public mint. This is useful for mints where you want to allow specified users to have early access and (optionally) a lower mint price. After your defined allowlist window ends, the public mint will begin immediately. This contract uses [ERC721A](https://github.com/chiru-labs/ERC721A) as base to allow for more efficient minting of multiple NFTs in a single transaction.
 
 It also makes use of the following utility libraries for allowlist proof verification:
 

--- a/contracts/lib/murky/README.md
+++ b/contracts/lib/murky/README.md
@@ -35,7 +35,7 @@ assertTrue(verified);
 ```
 
 ### Notes
-* `Xorkle.sol` is implemented as a XOR tree. This allows for greater gas efficiency: hashes are calculated on 32 bytes instead of 64; it is agnostic of sibling order so there is less lt/gt branching. Note that XOR trees are not appropriate for all use-cases*.
+* `Xorkle.sol` is implemented as an XOR tree. This allows for greater gas efficiency: hashes are calculated on 32 bytes instead of 64; it is agnostic of sibling order so there is less lt/gt branching. Note that XOR trees are not appropriate for all use-cases*.
 
 * `Merkle.sol` is implemented using concatenation and thus is a generic merkle tree. It's less efficient, but is compatible with [OpenZeppelin's Prover](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/MerkleProof.sol) and other implementations. Use this one if you aren't sure. Compatiblity with OZ Prover is implemented as a fuzz test.
 


### PR DESCRIPTION
This pull request addresses several typos in the README files across the project. Changes include correcting the use of articles ("a" vs. "an") and adjusting phrasing for clarity and grammatical correctness.

**What changed? Why?**
- Replaced incorrect articles in sentences, ensuring proper grammar (e.g., changing "a ERC721A" to "an ERC721A").
- Corrected minor textual issues for improved clarity.

**Notes to reviewers**:
- The changes are purely grammatical and should not affect functionality.
- Review for consistency across documentation.

**How has it been tested?**
- No code changes, only documentation updates.
