### PR TITLE
Fix Typos and Broken Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > Accelerate your onchain creativity with the Build Onchain Apps Template. ☕️
 
-[![GitHub contributors](https://img.shields.io/github/contributors/coinbase/build-onchain-apps?color=3498DB)](https://github.com/coinbase/build-onchain-apps/graphs/contributors) [![GitHub Stars](https://img.shields.io/github/stars/coinbase/build-onchain-apps.svg?color=3498DB)](https://github.com/coinbase/build-onchain-apps/stargazers) [![GitHub](https://img.shields.io/github/license/coinbase/build-onchain-apps?color=3498DB)](https://github.com/coinbase/build-onchain-apps/blob/main/LICENSE)
+[![GitHub contributors](https://img.shields.io/github/contributors/coinbase/build-onchain-apps?color=3498DB)](https://github.com/coinbase/build-onchain-apps/graphs/contributors) [![GitHub Stars](https://img.shields.io/github/stars/coinbase/build-onchain-apps.svg?color=3498DB)](https://github.com/coinbase/build-onchain-apps/stargazers) [![GitHub](https://img.shields.io/github/license/coinbase/build-onchain-apps?color=3498DB)](https://github.com/coinbase/build-onchain-apps/blob/main/LICENSE.md)
 
 <br />
 

--- a/contracts/lib/ERC721A/README.md
+++ b/contracts/lib/ERC721A/README.md
@@ -13,7 +13,7 @@
 
 > **📢 Version 4.x introduces several breaking changes. [Please refer to the documentation for more details.](https://chiru-labs.github.io/ERC721A/#/migration)**
 
-_We highly recommend reading the migration guide_, **especially** _the part on [`supportsInterface`](https://chiru-labs.github.io/ERC721A/#/migration?id=supportsinterface) if you are using with OpenZeppelin extensions_ (e.g. ERC2981).
+_We highly recommend reading the migration guide_, **especially** _the part on [`supportsInterface`](https://chiru-labs.github.io/ERC721A/#/migration?id=supportsinterface) if you are using it with OpenZeppelin extensions_ (e.g. ERC2981).
 
 <!-- ABOUT THE PROJECT -->
 

--- a/contracts/lib/murky/README.md
+++ b/contracts/lib/murky/README.md
@@ -7,7 +7,7 @@ Murky contains contracts that can generate merkle roots and proofs. Murky also p
 
 The root generation, proof generation, and verification functions are all fuzz tested (configured 5,000 runs by default) using arbitrary bytes32 arrays and uint leaves. There is also standardized testing and differential testing.
 
-> Note: Code is not audited (yet). Please do your own due dilligence testing if you are planning to use this code!
+> Note: Code is not audited (yet). Please do your own due diligence testing if you are planning to use this code!
 
 You can currently see Murky in action in the [Seaport](https://github.com/ProjectOpenSea/Seaport) test suite.
 
@@ -37,12 +37,12 @@ assertTrue(verified);
 ### Notes
 * `Xorkle.sol` is implemented as a XOR tree. This allows for greater gas efficiency: hashes are calculated on 32 bytes instead of 64; it is agnostic of sibling order so there is less lt/gt branching. Note that XOR trees are not appropriate for all use-cases*.
 
-* `Merkle.sol` is implemented using concatenation and thus is a generic merkle tree. It's less efficient, but is compatible with [OpenZeppelin's Prover](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/MerkleProof.sol) and other implementations. Use this one if you aren't sure. Compatiblity with OZ Prover is implemented as a fuzz test.
+* `Merkle.sol` is implemented using concatenation and thus is a generic merkle tree. It's less efficient, but is compatible with [OpenZeppelin's Prover](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/MerkleProof.sol) and other implementations. Use this one if you aren't sure. Compatibility with OZ Prover is implemented as a fuzz test.
 
 ### Script
 `Merkle.s.sol` is implemented using `forge-std` for quick and simple interaction with the core contracts. The script reads from `script/target/input.json`, generates merkle proof using `Merkle.sol` and then outputs at `script/target/output.json`.
 
-The hashes of the leafs are generated using `keccak256(bytes.concat(keccak256(abi.encode(...))))`, which is the same as [`OpenZeppelin/merkle-tree`](https://github.com/OpenZeppelin/merkle-tree#validating-a-proof-in-solidity).
+The hashes of the leaves are generated using `keccak256(bytes.concat(keccak256(abi.encode(...))))`, which is the same as [`OpenZeppelin/merkle-tree`](https://github.com/OpenZeppelin/merkle-tree#validating-a-proof-in-solidity).
 
 ```bash
 forge script script/Merkle.s.sol
@@ -59,9 +59,9 @@ forge snapshot --ffi --match-path src/test/StandardInput.t.sol
 
 Passing just standardized tests is not sufficient for implementation changes. All changes must pass all tests, preferably with 10,000+ fuzz runs.
 
-There is also early support for [differential  testing](./differential_testing/).
+There is also early support for [differential testing](./differential_testing/).
 
-> * It's possible that an improvement is not adequetly revealed by the current standardized data. If that is the case, new standard data should be provided with an accompanying description/justification.
+> * It's possible that an improvement is not adequately revealed by the current standardized data. If that is the case, new standard data should be provided with an accompanying description/justification.
 
 #### Latest Gas
 ![gas report](./reports/murky_gas_report.png)


### PR DESCRIPTION
### Corrected typos:

**"due dilligence" → "due diligence"
"leafs" → "leaves"
"compatiblity" → "compatibility"
"adequetly" → "adequately"**

### Updated a broken link:

**LICENSE → LICENSE.md (the previous link did not work).**