### PR TITLE
chore: Update ReadMe for build-onchain-apps shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+# Deprecation Notice
+
+> ⚠️ **Important:** Build-onchain-apps has been deprecated as of February 5, 2025.
+## What This Means
+
+This service is no longer actively maintained or supported.
+
+## Need Help?
+
+If you have any questions or concerns:
+- Contact our support team through [Discord](https://discord.gg/vbpeXpkPkw)
+
 <img src='./docs/logo-v-0-17.png' width='800' alt='Build Onchain Apps Template'>
 
 # [Build Onchain Apps Template (⛵️)](https://github.com/coinbase/build-onchain-apps/)


### PR DESCRIPTION
**What changed? Why?**
`build-onchain-apps` has been deprecated. Update ReadMe to inform users.

<img width="944" alt="Screenshot 2025-02-05 at 9 43 29 AM" src="https://github.com/user-attachments/assets/2b8b6cda-d762-42fb-a5d3-4366adb48f9a" />

**Notes to reviewers**


**How has it been tested?**
